### PR TITLE
Change slug of ESTRO community from `estro` to `rs4rt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repo contains a script for importing ESTRO software from a CSV file.
 
 This script follows a standard Maven setup. The CSV file can be found in the resources.
 
-Before this script is ran, an RSD must be running with a community with slug `estro`.
+Before this script is ran, an RSD must be running with a community with slug `rs4rt`.
 
 The Java program expects two arguments, which are in order:
 

--- a/src/main/java/nl/esciencecenter/RsdApiConnector.java
+++ b/src/main/java/nl/esciencecenter/RsdApiConnector.java
@@ -68,7 +68,7 @@ public class RsdApiConnector {
 		getAllRepoUrls();
 
 		try (HttpClient client = HttpClient.newHttpClient()) {
-			URI communityUrl = URI.create(domain.toASCIIString() + "/api/v1/community?slug=eq.estro");
+			URI communityUrl = URI.create(domain.toASCIIString() + "/api/v1/community?slug=eq.rs4rt");
 			HttpRequest httpRequest = HttpRequest.newBuilder()
 					.uri(communityUrl)
 					.GET()


### PR DESCRIPTION
This PR updates the required slug from `estro` to `rs4rt`.

closes #4